### PR TITLE
Fix a bug with Multiple filter on boolean column

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -782,7 +782,7 @@ class LivewireDatatable extends Component
                 } elseif ($value == 1) {
                     $query->where(DB::raw($this->getColumnField($index)[0]), '>', 0);
                 } elseif (strlen($value)) {
-                    $query->where(function($query) use ($index) {
+                    $query->where(function ($query) use ($index) {
                         $query->whereNull(DB::raw($this->getColumnField($index)[0]))
                             ->orWhere(DB::raw($this->getColumnField($index)[0]), 0);
                     });


### PR DESCRIPTION
There is a bug with parenthesis on sql query with making a query on 2 boolean column with the "false" condition.

Making something like: col 1 = true AND col 2 = false OR col 2 is null

The fix do: col 1 = true AND (col 2 = false OR col 2 is null)