### PR TITLE
Added with functionality to columns

### DIFF
--- a/resources/views/livewire/datatables/header-inline-hide.blade.php
+++ b/resources/views/livewire/datatables/header-inline-hide.blade.php
@@ -13,7 +13,7 @@
     </svg>
 </div>
 <div
-    class="@if($column['hidden']) hidden @else relative h-12 overflow-hidden align-top flex table-cell @endif">
+    class="@if($column['hidden']) hidden @else relative h-12 overflow-hidden align-top flex table-cell @endif" @if (isset($column['width']))style="width:{{ $column['width'] }}"@endif>
     <button wire:click.prefetch="sort('{{ $index }}')"
         class="w-full h-full px-6 py-3 border-b border-gray-200 bg-gray-50 text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex justify-between items-center focus:outline-none">
         <span class="inline flex-grow @if($column['align'] === 'right') text-right @elseif($column['align'] === 'center') text-center @endif"">{{ str_replace('_', ' ', $column['label']) }}</span>

--- a/resources/views/livewire/datatables/header-no-hide.blade.php
+++ b/resources/views/livewire/datatables/header-no-hide.blade.php
@@ -1,6 +1,6 @@
 @if($column['hidden'])
 @else
-<div class="relative table-cell h-12 overflow-hidden align-top">
+<div class="relative table-cell h-12 overflow-hidden align-top" @if (isset($column['width']))style="width:{{ $column['width'] }}"@endif>
     <button wire:click.prefetch="sort('{{ $index }}')" class="w-full h-full px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider flex items-center focus:outline-none @if($column['align'] === 'right') flex justify-end @elseif($column['align'] === 'center') flex justify-center @endif">
         <span class="inline ">{{ str_replace('_', ' ', $column['label']) }}</span>
         <span class="inline text-xs text-blue-400">

--- a/src/Column.php
+++ b/src/Column.php
@@ -27,6 +27,7 @@ class Column
     public $filterView;
     public $align = 'left';
     public $preventExport;
+    public $width;
 
     public static function name($name)
     {
@@ -254,4 +255,23 @@ class Column
 
         return $this;
     }
+
+    public function width($width)
+    {
+        // only numbers? add the default px unit
+        if (preg_match('/^\\d*\\.?\\d+$/i', $width) === 1) {
+            $width .= 'px';
+        }
+
+        // check if the $with contains invalid units
+        if (preg_match('/^(\\d*\\.?\\d+)\\s?(cm|mm|in|px|pt|pc|em|ex|ch|rem|vw|vmin|vmax|%+)$/i', $width) === 0) {
+            return $this;
+        }
+
+        $this->width = $width;
+
+        return $this;
+    }
+
+
 }

--- a/src/Column.php
+++ b/src/Column.php
@@ -272,6 +272,4 @@ class Column
 
         return $this;
     }
-
-
 }

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -229,5 +229,4 @@ class ColumnTest extends TestCase
             'width' => '5px',
         ], $subject);
     }
-
 }

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -91,6 +91,7 @@ class ColumnTest extends TestCase
             'aggregate' => 'group_concat',
             'align' => 'left',
             'preventExport' => null,
+            'width' => null,
         ], $subject);
     }
 
@@ -125,6 +126,108 @@ class ColumnTest extends TestCase
             'joins' => null,
             'align' => 'left',
             'preventExport' => null,
+            'width' => null,
         ], $subject);
     }
+
+    /** @test */
+    public function it_returns_width_property_from_column()
+    {
+        $subject = Column::name('table.column')
+            ->label('Column')
+            ->width('1em')
+            ->toArray();
+
+        $this->assertEquals([
+            'type' => 'string',
+            'name' => 'table.column',
+            'base' => null,
+            'label' => 'Column',
+            'filterable' => null,
+            'hidden' => null,
+            'callback' => null,
+            'raw' => null,
+            'sort' => null,
+            'defaultSort' => null,
+            'searchable' => null,
+            'params' => [],
+            'additionalSelects' => [],
+            'scope' => null,
+            'scopeFilter' => null,
+            'filterView' => null,
+            'select' => null,
+            'joins' => null,
+            'aggregate' => 'group_concat',
+            'align' => 'left',
+            'preventExport' => null,
+            'width' => '1em',
+        ], $subject);
+    }
+
+    public function check_invalid_width_unit_not_returning_value()
+    {
+        $subject = Column::name('table.column')
+            ->label('Column')
+            ->width('1laravel')
+            ->toArray();
+
+        $this->assertEquals([
+            'type' => 'string',
+            'name' => 'table.column',
+            'base' => null,
+            'label' => 'Column',
+            'filterable' => null,
+            'hidden' => null,
+            'callback' => null,
+            'raw' => null,
+            'sort' => null,
+            'defaultSort' => null,
+            'searchable' => null,
+            'params' => [],
+            'additionalSelects' => [],
+            'scope' => null,
+            'scopeFilter' => null,
+            'filterView' => null,
+            'select' => null,
+            'joins' => null,
+            'aggregate' => 'group_concat',
+            'align' => 'left',
+            'preventExport' => null,
+            'width' => null,
+        ], $subject);
+    }
+
+    public function check_adding_px_to_numeric_width_input()
+    {
+        $subject = Column::name('table.column')
+            ->label('Column')
+            ->width('5')
+            ->toArray();
+
+        $this->assertEquals([
+            'type' => 'string',
+            'name' => 'table.column',
+            'base' => null,
+            'label' => 'Column',
+            'filterable' => null,
+            'hidden' => null,
+            'callback' => null,
+            'raw' => null,
+            'sort' => null,
+            'defaultSort' => null,
+            'searchable' => null,
+            'params' => [],
+            'additionalSelects' => [],
+            'scope' => null,
+            'scopeFilter' => null,
+            'filterView' => null,
+            'select' => null,
+            'joins' => null,
+            'aggregate' => 'group_concat',
+            'align' => 'left',
+            'preventExport' => null,
+            'width' => '5px',
+        ], $subject);
+    }
+
 }


### PR DESCRIPTION
This PR adds width functionality to the column classes so you can define the width of your table columns

NumberColumn::name('id')->width('1%'),

In this example the width of the index column is set to 1% of the width of the table so we will have a nice and narrow ID column

